### PR TITLE
pull descriptor values for all namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ show_stacktrace: True
 ```
 * (optional) `state_dir` is where [state](#state) is stored. The default is `~/.lightbeam/` on *nix systems, `C:/Users/USER/.lightbeam/` on Windows systems.
 * (optional) Specify the `data_dir` which contains JSONL files to send to Ed-Fi. The default is `./`. The tool will look for files like `{Resource}.jsonl` or `{Descriptor}.jsonl` in this location, as well as directory-based files like `{Resource}/*.jsonl` or `{Descriptor}/*.jsonl`. Files with `.ndjson` or simply `.json` extensions will also be processed. (More info at the [`ndjson` standard page](http://dataprotocols.org/ndjson/).)
-* (optional) Specify the `namespace` to use when accessing the Ed-Fi API. The default is `ed-fi` but others include `tpdm` or custom values.
+* (optional) Specify the `namespace` to use when accessing the Ed-Fi API. The default is `ed-fi` but others include `tpdm` or custom values. To send data to multiple namespaces, you must use a YAML configuration file and `lightbeam send` for each.
 * Specify the details of the `edfi_api` to which to connect including
   * (optional) The `base_url` The default is `https://localhost/api` (the address of an Ed-Fi API [running locally in Docker](https://techdocs.ed-fi.org/display/EDFITOOLS/Docker+Deployment)).
   * The `version` as one of `3` or `2` (`2` is currently unsupported).

--- a/lightbeam/delete.py
+++ b/lightbeam/delete.py
@@ -114,7 +114,8 @@ class Deleter:
                     await asyncio.sleep(1)
             
                 # we have to get the `id` for a particular resource by first searching for its natural keys
-                async with client.get(util.url_join(self.lightbeam.api.config["data_url"], endpoint), params=params,
+                async with client.get(util.url_join(self.lightbeam.api.config["data_url"], self.lightbeam.config["namespace"], endpoint),
+                                        params=params,
                                         ssl=self.lightbeam.config["connection"]["verify_ssl"],
                                         headers=self.lightbeam.api.headers) as get_response:
                     body = await get_response.text()
@@ -126,7 +127,7 @@ class Deleter:
                             if type(j)==list and len(j)==1:
                                 the_id = j[0]['id']
                                 # now we can delete by `id`
-                                async with client.delete(util.url_join(self.lightbeam.api.config["data_url"], endpoint, the_id),
+                                async with client.delete(util.url_join(self.lightbeam.api.config["data_url"], self.lightbeam.config["namespace"], endpoint, the_id),
                                                             ssl=self.lightbeam.config["connection"]["verify_ssl"],
                                                             headers=self.lightbeam.api.headers) as delete_response:
                                     body = await delete_response.text()

--- a/lightbeam/send.py
+++ b/lightbeam/send.py
@@ -95,7 +95,8 @@ class Sender:
                 while self.lightbeam.is_locked:
                     await asyncio.sleep(1)
                 
-                async with client.post(util.url_join(self.lightbeam.api.config["data_url"], endpoint), data=data,
+                async with client.post(util.url_join(self.lightbeam.api.config["data_url"], self.lightbeam.config["namespace"], endpoint),
+                                        data=data,
                                         ssl=self.lightbeam.config["connection"]["verify_ssl"],
                                         headers=self.lightbeam.api.headers) as response:
                     body = await response.text()


### PR DESCRIPTION
Previously, only descriptors for the namespace specified in your YAML would be pulled. This update pulls _all_ descriptor values from any namespace.