### PR TITLE
fixing a bug with Ed-Fi 6.1 APIs dependencies

### DIFF
--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -154,6 +154,10 @@ class EdFiAPI:
         except Exception as e:
             self.logger.critical("Unable to load dependencies from API... terminating. Check API connectivity. ({0})".format(str(e)))
         
+        # Sort `data` by order (not sorted by default in Ed-Fi 6.1)
+        data = list(filter(lambda x: "Create" in x['operations'], data))
+        data = sorted(data, key=lambda x: x['order'])
+
         ordered_endpoints = []
         for e in data:
             ordered_endpoints.append(e["resource"].replace('/' + self.lightbeam.config["namespace"] + '/', ""))


### PR DESCRIPTION
lightbeam uses the Ed-Fi API's dependencies endpoint to determine in which order to send resources. In Ed-Fi 5.1, this endpoint appears to have sorted resources in order. However E-d-Fi 6.1 produces the resources alphabetically. Moreover, it may show a resource twice (one with Create operation, another with Update operation), which caused lightbeam to send that resource twice.

This PR fixes this bug by filtering the list of resources returned by the dependencies endpoint to only those with a Create operation, and then sorting the resources according to the order property.