### PR TITLE
fixing a bug with per-request timeout

### DIFF
--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -80,7 +80,7 @@ class EdFiAPI:
     # Returns a client object with exponential retry and other parameters per configs
     def get_retry_client(self):
         return RetryClient(
-            timeout=aiohttp.ClientTimeout(total=self.lightbeam.config['connection']["timeout"]),
+            timeout=aiohttp.ClientTimeout(sock_connect=self.lightbeam.config['connection']["timeout"]),
             retry_options=ExponentialRetry(
                 attempts=self.lightbeam.config['connection']["num_retries"],
                 factor=self.lightbeam.config['connection']["backoff_factor"],

--- a/lightbeam/send.py
+++ b/lightbeam/send.py
@@ -87,14 +87,14 @@ class Sender:
     
     # Posts a single data payload to a single endpoint using the client
     async def do_post(self, endpoint, file_name, data, client, line, hash):
-        try:
-            status = 401
-            while status==401:
-                
-                # wait if another process has locked lightbeam while we refresh the oauth token:
-                while self.lightbeam.is_locked:
-                    await asyncio.sleep(1)
-                
+        status = 401
+        while status==401:
+            
+            # wait if another process has locked lightbeam while we refresh the oauth token:
+            while self.lightbeam.is_locked:
+                await asyncio.sleep(1)
+            
+            try:
                 async with client.post(util.url_join(self.lightbeam.api.config["data_url"], self.lightbeam.config["namespace"], endpoint),
                                         data=data,
                                         ssl=self.lightbeam.config["connection"]["verify_ssl"],
@@ -122,7 +122,8 @@ class Sender:
                     else:
                         self.lightbeam.api.update_oauth()
         
-        except Exception as e:
-            self.lightbeam.num_errors += 1
-            self.logger.warn("{0}  (at line {1} of {2} )".format(str(e), line, file_name))
+            except Exception as e:
+                status = 400
+                self.lightbeam.num_errors += 1
+                self.logger.warn("{0}  (at line {1} of {2} )".format(str(e), line, file_name))
 


### PR DESCRIPTION
`lightbeam send` works by enqueueing requests (`MAX_TASK_QUEUE_SIZE = 1000` at a time) and then asynchronously processing the queue using `config.pool_size` workers.

Previously, the per-request timeout "clock" started counting as soon as a request was enqueued, so it included all the time it waited in the queue for an available connection from the pool. If the queue size was large compared to `pool_size` and/or the Ed-Fi API was particularly slow, you could wind up in an infinite loop where the aiohttp.RetryClient would perpetually timeout and requeue tasks, so lightbeam would never finish.

This update changes the timeout behavior to measure time from when a request begins actually processing.