### PR TITLE
create results_file path if it does not already exist

### DIFF
--- a/lightbeam/send.py
+++ b/lightbeam/send.py
@@ -66,7 +66,14 @@ class Sender:
                             total_num_errs += num_errs
                     status_metadata.update({"count": total_num_errs})
         
+        ### Create structured output results_file if necessary
         if self.lightbeam.results_file:
+            
+            # create directory if not exists
+            results_dir = os.path.dirname(self.lightbeam.results_file)
+            if not os.path.isdir(results_dir):
+                os.makedirs(results_dir)
+            
             with open(self.lightbeam.results_file, 'w') as fp:
                 fp.write(json.dumps(self.metadata, indent=4))
 

--- a/lightbeam/send.py
+++ b/lightbeam/send.py
@@ -70,9 +70,7 @@ class Sender:
         if self.lightbeam.results_file:
             
             # create directory if not exists
-            results_dir = os.path.dirname(self.lightbeam.results_file)
-            if not os.path.isdir(results_dir):
-                os.makedirs(results_dir)
+            os.makedirs(os.path.dirname(self.lightbeam.results_file), exist_ok=True)
             
             with open(self.lightbeam.results_file, 'w') as fp:
                 fp.write(json.dumps(self.metadata, indent=4))


### PR DESCRIPTION
This PR fixes a bug where if the path to the specified results_file does not exist, lightbeam would fail instead of just creating it.