### PR TITLE
fix typo in descriptor CSV header

### DIFF
--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -277,7 +277,7 @@ class EdFiAPI:
             # save
             if self.lightbeam.track_state:
                 self.logger.debug(f"saving descriptor values to {cache_file}...")
-                header = ['desriptor', 'namespace', 'codeValue', 'shortDescription', 'description']
+                header = ['descriptor', 'namespace', 'codeValue', 'shortDescription', 'description']
                 with open(cache_file, 'w', encoding='UTF8', newline='') as f:
                     writer = csv.writer(f)
                     writer.writerow(header)


### PR DESCRIPTION
This PR fixes a typo I discovered in the header of the CSV of descriptor values lightbeam creates. It's non-breaking, since [the code that uses it](https://github.com/edanalytics/lightbeam/blob/5f09fcf0b9e2d7f0ee41b5d2b6da828e2742d4c6/lightbeam/validate.py#L114) refers to columns by index, not name.