### PR TITLE
fixes a bug when fetching resources without read permission

### DIFF
--- a/lightbeam/fetch.py
+++ b/lightbeam/fetch.py
@@ -33,7 +33,10 @@ class Fetcher:
         record_counts = self.lightbeam.results
         self.lightbeam.results = []
         for endpoint in self.lightbeam.endpoints:
-            num_records = [x for x in record_counts if x[0] == endpoint][0][1]
+            try:
+                num_records = [x for x in record_counts if x[0] == endpoint][0][1]
+            except IndexError:
+                continue
             num_pages = math.ceil(num_records / limit)
             
             # do the requests


### PR DESCRIPTION
[lightbeam's `fetch` command](https://github.com/edanalytics/lightbeam#fetch) first `count`s the number of records in each resource before actually `fetch`ing them (in order to know how many pages of results to `fetch`). This relatively simple PR fixes a bug where lightbeam would die with an exception when trying to access the record counts for resources we don't have permission to read.