### PR TITLE
`definitions` in swagger were renamed to `components.schemas` in Ed-Fi 7.1

### DIFF
--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -344,22 +344,22 @@ class EdFiAPI:
 
     def get_required_params_from_swagger(self, swagger, definition, prefix=""):
         params = {}
-        use_paths = False
+        use_definitions = False
         if "definitions" in swagger.keys():
             schema = swagger["definitions"][definition]
-        elif "paths" in swagger.keys():
-            schema = swagger["paths"][definition]
-            use_paths = True
+            use_definitions = True
+        elif "components" in swagger.keys() and "schemas" in swagger["components"].keys():
+            schema = swagger["components"]["schemas"][definition]
         else:
-            self.logger.critical(f"Swagger contains neither `definitions` nor `paths` - check that the Swagger is valid.")
+            self.logger.critical(f"Swagger contains neither `definitions` nor `components.schemas` - check that the Swagger is valid.")
         
         for requiredProperty in schema["required"]:
             if "$ref" in schema["properties"][requiredProperty].keys():
                 sub_definition = schema["properties"][requiredProperty]["$ref"]
-                if use_paths:
-                    sub_definition = sub_definition.replace("#/paths/", "")
-                else:
+                if use_definitions:
                     sub_definition = sub_definition.replace("#/definitions/", "")
+                else:
+                    sub_definition = sub_definition.replace("#/components/schemas/", "")
                 sub_params = self.get_required_params_from_swagger(swagger, sub_definition, prefix=requiredProperty+".")
                 for k,v in sub_params.items():
                     params[k] = v

--- a/lightbeam/validate.py
+++ b/lightbeam/validate.py
@@ -33,10 +33,10 @@ class Validator:
         definition = util.camel_case(self.lightbeam.config["namespace"]) + "_" + util.singularize_endpoint(endpoint)
         if "definitions" in swagger.keys():
             resource_schema = swagger["definitions"][definition]
-        elif "paths" in swagger.keys():
-            resource_schema = swagger["paths"][definition]
+        elif "components" in swagger.keys() and "schemas" in swagger["components"].keys():
+            resource_schema = swagger["components"]["schemas"][definition]
         else:
-            self.logger.critical(f"Swagger contains neither `definitions` nor `paths` - check that the Swagger is valid.")
+            self.logger.critical(f"Swagger contains neither `definitions` nor `components.schemas` - check that the Swagger is valid.")
         
         resolver = RefResolver("test", swagger, swagger)
         validator = Draft4Validator(resource_schema, resolver=resolver)

--- a/lightbeam/validate.py
+++ b/lightbeam/validate.py
@@ -31,8 +31,13 @@ class Validator:
     # Validates a single endpoint based on the Swagger docs
     def validate_endpoint(self, swagger, endpoint, local_descriptors=[]):
         definition = util.camel_case(self.lightbeam.config["namespace"]) + "_" + util.singularize_endpoint(endpoint)
-        resource_schema = swagger["definitions"][definition]
-
+        if "definitions" in swagger.keys():
+            resource_schema = swagger["definitions"][definition]
+        elif "paths" in swagger.keys():
+            resource_schema = swagger["paths"][definition]
+        else:
+            self.logger.critical(f"Swagger contains neither `definitions` nor `paths` - check that the Swagger is valid.")
+        
         resolver = RefResolver("test", swagger, swagger)
         validator = Draft4Validator(resource_schema, resolver=resolver)
         params_structure = self.lightbeam.api.get_params_for_endpoint(endpoint)


### PR DESCRIPTION
@megan-nash-ea pointed out that in Ed-Fi 7.1, `definitions` in Swagger were renamed to `components.schemas`. `definitions` were hard-coded, this PR makes lightbeam also look for `components.schemas` instead (if that exists), and also throws an error if nether `definitions` nor `components.schemas` exist.