### PR TITLE
fixes a bug where none of the descriptor payload keys were kept after being downloaded

### DIFF
--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -256,8 +256,12 @@ class EdFiAPI:
             # load descriptor values from API
             selector_backup = self.lightbeam.selector
             exclude_backup = self.lightbeam.exclude
+            keep_keys_backup = self.lightbeam.keep_keys
+            drop_keys_backup = self.lightbeam.drop_keys
             self.lightbeam.selector = "*Descriptors"
             self.lightbeam.exclude = ""
+            self.lightbeam.keep_keys = "*"
+            self.lightbeam.drop_keys = ""
             self.logger.debug(f"fetching descriptor values...")
             all_endpoints = self.get_sorted_endpoints()
             self.lightbeam.endpoints = self.apply_filters(all_endpoints)
@@ -281,6 +285,8 @@ class EdFiAPI:
             self.lightbeam.results = []
             self.lightbeam.selector = selector_backup
             self.lightbeam.exclude = exclude_backup
+            self.lightbeam.keep_keys = keep_keys_backup
+            self.lightbeam.drop_keys = drop_keys_backup
             self.prepare()
 
 


### PR DESCRIPTION
The new implementation of wildcard support in `--keep-keys` and `--drop-keys` apparently makes `load_descriptors_values()` drop all the keys from descriptor value payloads, resulting in an key error. (Thanks to @megan-nash-ea for pointing out this issue.) This PR fixes the bug by first backing up any user-specified `keep-keys` and `drop-keys`, then explicitly setting `keep-keys=*` and `drop-keys=NULL` before fetching descriptor values from the Ed-Fi API.