### PR TITLE
Feature - Custom metadata URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ data_dir: ./
 namespace: ed-fi
 edfi_api:
   base_url: https://api.schooldistrict.org/v5.3/api
+  oauth_url: https://api.schooldistrict.org/v5.3/api/oauth/token 
+  dependencies_url: https://api.schooldistrict.org/v5.3/api/metadata/data/v3/2024/dependencies
+  descriptors_swagger_url: https://api.schooldistrict.org/v5.3/api/metadata/data/v3/2024/descriptors/swagger.json
+  resources_swagger_url: https://api.schooldistrict.org/v5.3/api/metadata/data/v3/2024/resources/swagger.json
   version: 3
   mode: year_specific
   year: 2021
@@ -68,6 +72,11 @@ show_stacktrace: True
 * (optional) Specify the `namespace` to use when accessing the Ed-Fi API. The default is `ed-fi` but others include `tpdm` or custom values. To send data to multiple namespaces, you must use a YAML configuration file and `lightbeam send` for each.
 * Specify the details of the `edfi_api` to which to connect including
   * (optional) The `base_url` which serves a JSON object specifying the paths to data endpoints, Swagger, and dependencies. The default is `https://localhost/api` (the address of an Ed-Fi API [running locally in Docker](https://techdocs.ed-fi.org/display/EDFITOOLS/Docker+Deployment)), but the location varies depending on how Ed-Fi is deployed.
+  * If the metadata for a particular API is not located in the "default" location (at the root of the base_url), then ALL the following urls should be explicitly specified.  These can normally be left blank, unless you are encountering errors indicating that the metadata files cannot be found (such as "Could not parse response from [base_url]").
+    * (optional) `oauth_url` (usually [base_url]/oauth/token)
+    * (optional) `dependencies_url` (usually [base_url]/metadata/data/v3/dependencies)
+    * (optional) `descriptors_swagger_url` (usually [base_url]/metadata/data/v3/descriptors/swagger.json)
+    * (optional) `resources_swagger_url` (usually [base_url]/metadata/data/v3/resources/swagger.json)
   * The `version` as one of `3` or `2` (`2` is currently unsupported).
   * (optional) The `mode` as one of `shared_instance`, `sandbox`, `district_specific`, `year_specific`, or `instance_year_specific`.
   * (required if `mode` is `year_specific` or `instance_year_specific`) The `year` used to build the resource URL. The default is the current year.

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -24,6 +24,10 @@ class Lightbeam:
         "namespace": "ed-fi",
         "edfi_api": {
             "base_url": "",
+            "oauth_url": "", 
+            "dependencies_url": "",
+            "descriptors_swagger_url": "",
+            "resources_swagger_url": "",
             "version": 3,
             "mode": "year_specific",
             "year": datetime.today().year,


### PR DESCRIPTION
The Lightbeam code assumes that there will be a json file at the root of the API url that defines where the auth, dependencies, and swagger metadata files are located.  However, this isn't always the case.  Indiana DOE's DEX system is an example, where the file does not exist in the expected location, and the metadata files are also not in their "default" urls relative to the base url.  

Previously, this would prevent Lightbeam from being used to connect to these non-standard APIs, since there was no way to manually define metadata urls for a connection.

This update adds 4 optional configuration options in the source/destination yaml files, to explicitly define the auth, dependencies, descriptor swagger, and resource swagger metadata files locations.  If these are defined in the yaml config file, then Lightbeam will use the explicit option settings, and NOT attempt to automatically detect them.  If any of them are NOT defined, then it will attempt to find them in the default locations (preexisting behavior).  In other words, default behavior has not changed.

Readme has been updated to reflect this change. 