### PR TITLE
Feature: notify user of endpoints to be deleted

### DIFF
--- a/lightbeam/delete.py
+++ b/lightbeam/delete.py
@@ -17,11 +17,6 @@ class Deleter:
     
     # Deletes data matching payloads in config.data_dir for selected endpoints
     def delete(self):
-        # prompt to confirm this destructive operation
-        if not self.lightbeam.config.get("force_delete", False):
-            if input('Type "yes" to confirm you want to delete payloads for the selected endpoints? ')!="yes":
-                exit('You did not type "yes" - exiting.')
-        
         # load swagger docs, so we can find natural keys for each resource and query the API for existing records to delete
         self.lightbeam.api.load_swagger_docs()
         
@@ -36,6 +31,9 @@ class Deleter:
         # process endpoints in reverse-dependency order, so we don't get dependency errors
         endpoints = copy.deepcopy(endpoints)
         endpoints.reverse()
+
+        # prompt to confirm this destructive operation
+        self.lightbeam.confirm_delete(endpoints)
 
         for endpoint in endpoints:
             # it doesn't seem possible to delete students once you've sent them

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -146,8 +146,8 @@ class Lightbeam:
         if self.config.get("force_delete", False):
             return
 
-        endpoint_list = "\n\t".join(endpoints)
-        print(f'Preparing to delete the following endpoints:\n\t{endpoint_list}')
+        endpoint_list = "\n\t • ".join(endpoints)
+        print(f'Preparing to delete the following endpoints:\n\t • {endpoint_list}')
         if input(f'Type "yes" to confirm you want to {verbiage} payloads for the selected endpoints? ')!="yes":
             exit('You did not type "yes" - exiting.')
 

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -147,7 +147,7 @@ class Lightbeam:
             return
 
         endpoint_list = "\n\t".join(endpoints)
-        self.logger.info(f'Preparing to delete the following endpoints:\n{endpoint_list}')
+        self.logger.info(f'Preparing to delete the following endpoints:\n\t{endpoint_list}')
         if input(f'Type "yes" to confirm you want to {verbiage} payloads for the selected endpoints? ')!="yes":
             exit('You did not type "yes" - exiting.')
 

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -141,7 +141,21 @@ class Lightbeam:
                     or (self.newer_than and tuple[0]>self.newer_than)
                     or (len(self.resend_status_codes)>0 and tuple[1] in self.resend_status_codes)
                 )
+    
+    def _confirm_delete_op(self, endpoints, verbiage):
+        if self.lightbeam.config.get("force_delete", False):
+            return
 
+        endpoint_list = "\n\t".join(endpoints)
+        self.logger.info(f'Preparing to delete the following endpoints:\n{endpoint_list}')
+        if input(f'Type "yes" to confirm you want to {verbiage} payloads for the selected endpoints? ')!="yes":
+            exit('You did not type "yes" - exiting.')
+
+    def confirm_delete(self, endpoints):
+        self._confirm_delete_op(endpoints, "delete")
+
+    def confirm_delete(self, endpoints):
+        self._confirm_delete_op(endpoints, "TRUNCATE ALL DATA")
 
     ################### Data discovery and loading methods ####################
     

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -154,7 +154,7 @@ class Lightbeam:
     def confirm_delete(self, endpoints):
         self._confirm_delete_op(endpoints, "delete")
 
-    def confirm_delete(self, endpoints):
+    def confirm_truncate(self, endpoints):
         self._confirm_delete_op(endpoints, "TRUNCATE ALL DATA")
 
     ################### Data discovery and loading methods ####################

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -147,7 +147,7 @@ class Lightbeam:
             return
 
         endpoint_list = "\n\t".join(endpoints)
-        self.logger.info(f'Preparing to delete the following endpoints:\n\t{endpoint_list}')
+        print(f'Preparing to delete the following endpoints:\n\t{endpoint_list}')
         if input(f'Type "yes" to confirm you want to {verbiage} payloads for the selected endpoints? ')!="yes":
             exit('You did not type "yes" - exiting.')
 

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -146,7 +146,7 @@ class Lightbeam:
         if self.config.get("force_delete", False):
             return
 
-        endpoint_list = "\n\t • ".join(endpoints)
+        endpoint_list = "\n\t - ".join(endpoints)
         print(f'Preparing to delete the following endpoints:\n\t • {endpoint_list}')
         if input(f'Type "yes" to confirm you want to {verbiage} payloads for the selected endpoints? ')!="yes":
             exit('You did not type "yes" - exiting.')

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -143,7 +143,7 @@ class Lightbeam:
                 )
     
     def _confirm_delete_op(self, endpoints, verbiage):
-        if self.lightbeam.config.get("force_delete", False):
+        if self.config.get("force_delete", False):
             return
 
         endpoint_list = "\n\t".join(endpoints)

--- a/lightbeam/truncate.py
+++ b/lightbeam/truncate.py
@@ -17,17 +17,15 @@ class Truncator:
     
     # Deletes all data in the Ed-Fi API for selected endpoints
     def truncate(self):
-        # prompt to confirm this destructive operation
-        if not self.lightbeam.config.get("force_delete", False):
-            if input('Type "yes" to confirm you want to TRUNCATE ALL DATA payloads for the selected endpoints? ')!="yes":
-                exit('You did not type "yes" - exiting.')
-        
         # get token with which to send requests
         self.lightbeam.api.do_oauth()
 
         # process endpoints in reverse-dependency order, so we don't get dependency errors
         endpoints = self.lightbeam.endpoints
         endpoints.reverse()
+
+        # prompt to confirm this destructive operation
+        self.lightbeam.confirm_truncate(endpoints)
 
         for endpoint in endpoints:
             # it doesn't seem possible to delete students once you've sent them


### PR DESCRIPTION
Add visibility to delete/truncate operations by displaying the affected endpoints to the user. Implements Part 1 of the Dry Run feature described [here](https://edanalytics.slite.com/app/docs/cOqC2kYj_CHrRI) and tracked [here](https://educationanalytics.monday.com/boards/6058716254/pulses/6788662764)