### PR TITLE
Fix missing descriptor description

### DIFF
--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -294,7 +294,7 @@ class EdFiAPI:
                 descriptor = ""
                 for key in v.keys():
                     if key.endswith("Id"): descriptor = key[0:-2]
-                self.descriptor_values.append([descriptor, v["namespace"], v["codeValue"], v["shortDescription"], v["description"]])
+                self.descriptor_values.append([descriptor, v["namespace"], v["codeValue"], v["shortDescription"], v.get("description", "")])
             
             # save
             if self.lightbeam.track_state:


### PR DESCRIPTION
The `description` field on Descriptors is optional in Ed-Fi, this fixes a bug in lightbeam (found by Luda) when they are missing.