### PR TITLE
update readme for structured log to current format

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,53 +302,48 @@ A sample results file could be:
 ```json
 {
     "started_at": "2023-06-08T17:18:25.053207",
-    "working_dir": "/home/someuser/code/sandbox/testing_lightbeam",
-    "config_file": "lightbeam.yml",
-    "data_dir": "./",
+    "working_dir": "/home/someuser/",
+    "config_file": "/home/someuser/lightbeam.yml",
+    "data_dir": "/home/someuser/data/",
     "api_url": "https://some-ed-fi-api.edu/api",
     "namespace": "ed-fi",
     "resources": {
         "studentSchoolAssociations": {
-            "failed_statuses": {
-                "400": {
-                    "400: { \"message\": \"The request is invalid.\", \"modelState\": { \"request.schoolReference.schoolId\": [ \"JSON integer 1234567899999 is too large or small for an Int32. Path 'schoolReference.schoolId', line 1, position 328.\" ] } }": {
-                        "files": {
-                            "./studentSchoolAssociations.jsonl": {
-                                "line_numbers": "6,4,5,7,8",
-                                "count": 5
-                            }
-                        }
-                    },
-                    "400: { \"message\": \"Validation of 'StudentSchoolAssociation' failed.\\n\\tStudent reference could not be resolved.\\n\" }": {
-                        "files": {
-                            "./studentSchoolAssociations.jsonl": {
-                                "line_numbers": "1,3,2",
-                                "count": 3
-                            }
-                        }
-                    },
-                    "count": 8
+            "records_processed": 50,
+            "records_skipped": 0,
+            "records_failed": 22,
+            "failures": [
+                {
+                    "status_code": 400,
+                    "message": "The request is invalid. \"request.schoolReference.schoolId\": [ \"JSON integer 1234567899999 is too large or small for an Int32. Path 'schoolReference.schoolId', line 1, position 328.\" ]",
+                    "file": "/home/someuser/data/studentSchoolAssociations.jsonl",
+                    "line_numbers": "6,4,5,7,8",
+                    "count": 5
                 },
-                "409": {
-                    "409: { \"message\": \"The value supplied for the related 'studentschoolassociation' resource does not exist.\" }": {
-                        "files": {
-                            "./studentSchoolAssociations.jsonl": {
-                                "line_numbers": "9,10,12,14,16,13,11,15,17,18,19,21,22,20",
-                                "count": 14
-                            }
-                        }
-                    },
+                {
+                    "status_code": 400,
+                    "message": "Validation of 'StudentSchoolAssociation' failed. Student reference could not be resolved.",
+                    "file": "/home/someuser/data/studentSchoolAssociations.jsonl",
+                    "line_numbers": "1,3,2",
+                    "count": 3
+
+                },
+                {
+                    "status_code": 409,
+                    "message": "The value supplied for the related 'studentschoolassociation' resource does not exist."
+                    "file": "/home/someuser/data/studentSchoolAssociations.jsonl",
+                    "line_numbers": "9,10,12,14,16,13,11,15,17,18,19,21,22,20",
                     "count": 14
                 }
-            },
-            "records_processed": 22,
+            ],
+            "records_processed": 50,
             "records_skipped": 0,
             "records_failed": 22
         }
     },
     "completed_at": "2023-06-08T17:18:26.724699",
     "runtime_sec": 1.671492,
-    "total_records_processed": 22,
+    "total_records_processed": 50,
     "total_records_skipped": 0,
     "total_records_failed": 22
 }


### PR DESCRIPTION
When [we changed](https://github.com/edanalytics/lightbeam/pull/24) the structure of the `--results-file` we never updated the example in the README. This PR fixes that.