### PR TITLE
This adds a successes section to the structured log results file to report how many payloads resulted in a 200, 201, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,12 @@ A sample results file could be:
                     "count": 14
                 }
             ],
+            "successes": [
+                {
+                    "status_code": 201,
+                    "count": 28
+                }
+            ],
             "records_processed": 50,
             "records_skipped": 0,
             "records_failed": 22

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -174,7 +174,7 @@ class Lightbeam:
         return file_list
 
     # Prunes the list of endpoints down to those for which .jsonl files exist in the config.data_dir
-    def get_endpoints_with_data(self):
+    def get_endpoints_with_data(self, filter_endpoints=None):
         self.logger.debug("discovering data...")
         endpoints_with_data = []
         data_dir_list = os.listdir(self.config["data_dir"])

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -174,7 +174,7 @@ class Lightbeam:
         return file_list
 
     # Prunes the list of endpoints down to those for which .jsonl files exist in the config.data_dir
-    def get_endpoints_with_data(self, filter_endpoints=None):
+    def get_endpoints_with_data(self):
         self.logger.debug("discovering data...")
         endpoints_with_data = []
         data_dir_list = os.listdir(self.config["data_dir"])

--- a/lightbeam/send.py
+++ b/lightbeam/send.py
@@ -163,6 +163,13 @@ class Sender:
             hashlog.save(hashlog_file, self.hashlog_data)
 
         # update metadata counts for this endpoint
+        statuses = self.lightbeam.status_counts.keys()
+        successes = []
+        for status in statuses:
+            if status>=200 and status<300:
+                successes.append({"status_code": status, "count": self.lightbeam.status_counts[status]})
+        if len(successes)>0:
+            self.metadata["resources"][endpoint].update({"successes": successes})
         self.metadata["resources"][endpoint].update({
             "records_processed": total_counter,
             "records_skipped": self.lightbeam.num_skipped,


### PR DESCRIPTION
(Implementing the suggestion from @rlittle08 in [this issue](https://github.com/edanalytics/lightbeam/issues/39).)