### PR TITLE
implementing structured results file output for validate

### DIFF
--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -133,10 +133,11 @@ class Lightbeam:
     def replace_linebreaks(self, m):
         return re.sub(r"\s+", '', m.group(0))
 
-    def write_structured_output(self):
+    def write_structured_output(self, command):
         ### Create structured output results_file if necessary
         self.end_timestamp = datetime.now()
         self.metadata.update({
+            "command": command,
             "completed_at": self.end_timestamp.isoformat(timespec='microseconds'),
             "runtime_sec": (self.end_timestamp - self.start_timestamp).total_seconds(),
             "total_records_processed": sum(item['records_processed'] for item in self.metadata["resources"].values()),

--- a/lightbeam/send.py
+++ b/lightbeam/send.py
@@ -36,7 +36,7 @@ class Sender:
             self.lightbeam.log_status_reasons()
         
         # write structured output (if needed)
-        self.lightbeam.write_structured_output()
+        self.lightbeam.write_structured_output("send")
 
         if self.lightbeam.metadata["total_records_processed"] == self.lightbeam.metadata["total_records_skipped"]:
             self.logger.info("all payloads skipped")

--- a/lightbeam/send.py
+++ b/lightbeam/send.py
@@ -3,7 +3,6 @@ import os
 import time
 import json
 import asyncio
-import datetime
 
 from lightbeam import util
 from lightbeam import hashlog
@@ -16,21 +15,9 @@ class Sender:
         self.lightbeam.reset_counters()
         self.logger = self.lightbeam.logger
         self.hashlog_data = {}
-        self.start_timestamp = datetime.datetime.now()
 
     # Sends all (selected) endpoints
     def send(self):
-
-        # Initialize a dictionary for tracking run metadata (for structured output)
-        self.metadata = {
-            "started_at": self.start_timestamp.isoformat(timespec='microseconds'),
-            "working_dir": os.getcwd(),
-            "config_file": self.lightbeam.config_file,
-            "data_dir": self.lightbeam.config["data_dir"],
-            "api_url": self.lightbeam.config["edfi_api"]["base_url"],
-            "namespace": self.lightbeam.config["namespace"],
-            "resources": {}
-        }
 
         # get token with which to send requests
         self.lightbeam.api.do_oauth()
@@ -47,43 +34,15 @@ class Sender:
             self.logger.info("finished processing endpoint {0}!".format(endpoint))
             self.logger.info("  (final status counts: {0}) ".format(self.lightbeam.status_counts))
             self.lightbeam.log_status_reasons()
+        
+        # write structured output (if needed)
+        self.lightbeam.write_structured_output()
 
-        ### Create structured output results_file if necessary
-        self.end_timestamp = datetime.datetime.now()
-        self.metadata.update({
-            "completed_at": self.end_timestamp.isoformat(timespec='microseconds'),
-            "runtime_sec": (self.end_timestamp - self.start_timestamp).total_seconds(),
-            "total_records_processed": sum(item['records_processed'] for item in self.metadata["resources"].values()),
-            "total_records_skipped": sum(item['records_skipped'] for item in self.metadata["resources"].values()),
-            "total_records_failed": sum(item['records_failed'] for item in self.metadata["resources"].values())
-        })
-        # sort failing line numbers
-        for resource in self.metadata["resources"].keys():
-            if "failures" in self.metadata["resources"][resource].keys():
-                for idx, _ in enumerate(self.metadata["resources"][resource]["failures"]):
-                    self.metadata["resources"][resource]["failures"][idx]["line_numbers"].sort()
-
-        # helper function used below
-        def repl(m):
-            return re.sub(r"\s+", '', m.group(0))
-
-        ### Create structured output results_file if necessary
-        if self.lightbeam.results_file:
-
-            # create directory if not exists
-            os.makedirs(os.path.dirname(self.lightbeam.results_file), exist_ok=True)
-
-            with open(self.lightbeam.results_file, 'w') as fp:
-                content = json.dumps(self.metadata, indent=4)
-                # failures.line_numbers are split each on their own line; here we remove those line breaks
-                content = re.sub(r'"line_numbers": \[(\d|,|\s|\n)*\]', repl, content)
-                fp.write(content)
-
-        if self.metadata["total_records_processed"] == self.metadata["total_records_skipped"]:
+        if self.lightbeam.metadata["total_records_processed"] == self.lightbeam.metadata["total_records_skipped"]:
             self.logger.info("all payloads skipped")
             exit(99) # signal to downstream tasks (in Airflow) all payloads skipped
 
-        if self.metadata["total_records_processed"] == self.metadata["total_records_failed"]:
+        if self.lightbeam.metadata["total_records_processed"] == self.lightbeam.metadata["total_records_failed"]:
             self.logger.info("all payloads failed")
             exit(1) # signal to downstream tasks (in Airflow) all payloads failed
 
@@ -100,7 +59,7 @@ class Sender:
             hashlog_file = os.path.join(self.lightbeam.config["state_dir"], f"{endpoint}.dat")
             self.hashlog_data = hashlog.load(hashlog_file)
 
-        self.metadata["resources"].update({endpoint: {}})
+        self.lightbeam.metadata["resources"].update({endpoint: {}})
         self.lightbeam.reset_counters()
 
         # process each file
@@ -169,8 +128,8 @@ class Sender:
             if status>=200 and status<300:
                 successes.append({"status_code": status, "count": self.lightbeam.status_counts[status]})
         if len(successes)>0:
-            self.metadata["resources"][endpoint].update({"successes": successes})
-        self.metadata["resources"][endpoint].update({
+            self.lightbeam.metadata["resources"][endpoint].update({"successes": successes})
+        self.lightbeam.metadata["resources"][endpoint].update({
             "records_processed": total_counter,
             "records_skipped": self.lightbeam.num_skipped,
             "records_failed": self.lightbeam.num_errors
@@ -199,7 +158,7 @@ class Sender:
                             message = str(response.status) + ": " + util.linearize(json.loads(body).get("message"))
 
                             # update run metadata...
-                            failures = self.metadata["resources"][endpoint].get("failures", [])
+                            failures = self.lightbeam.metadata["resources"][endpoint].get("failures", [])
                             do_append = True
                             for index, item in enumerate(failures):
                                 if item["status_code"]==response.status and item["message"]==message and item["file"]==file_name:
@@ -215,7 +174,7 @@ class Sender:
                                     'count': 1
                                 }
                                 failures.append(failure)
-                            self.metadata["resources"][endpoint]["failures"] = failures
+                            self.lightbeam.metadata["resources"][endpoint]["failures"] = failures
 
                             # update output and counters
                             self.lightbeam.increment_status_reason(message)

--- a/lightbeam/validate.py
+++ b/lightbeam/validate.py
@@ -68,7 +68,7 @@ class Validator:
             asyncio.run(self.validate_endpoint(endpoint))
         
         # write structured output (if needed)
-        self.lightbeam.write_structured_output()
+        self.lightbeam.write_structured_output("validate")
 
         if self.lightbeam.metadata["total_records_processed"] == self.lightbeam.metadata["total_records_failed"]:
             self.logger.info("all payloads failed")


### PR DESCRIPTION
This PR moves the code for creating a structured results file (with `lightbeam send --results-file ./results.json`) that was in `send.py` into `lightbeam.py` so it can be reused by `validate.py`. So you can now also call `lightbeam validate --results-file ./results.json` to get an output such as:
```json
{
    "started_at": "2024-08-13T10:31:46.906999",
    "working_dir": "/path/to/repos/lightbeam/example",
    "config_file": "./lightbeam.yml",
    "data_dir": "./",
    "api_url": "https://localhost/api",
    "namespace": "ed-fi",
    "resources": {
        "localEducationAgencies": {
            "records_processed": 10,
            "records_skipped": 0,
            "records_failed": 0
        },
        "schools": {
            "failures": [
                {
                    "method": "json",
                    "message": "invalid JSON Extra data: column 32 (char 31)",
                    "file": "./schools.jsonl",
                    "line_numbers":[0],
                    "count": 1
                },
                {
                    "method": "references",
                    "message": "payload contains an invalid localEducationAgencyReference : {\"localEducationAgencyId\": 99996320}",
                    "file": "./schools.jsonl",
                    "line_numbers":[1],
                    "count": 1
                },
                {
                    "method": "schema",
                    "message": "'schoolId' is a required property ",
                    "file": "./schools.jsonl",
                    "line_numbers":[2],
                    "count": 1
                },
                {
                    "method": "descriptors",
                    "message": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Schoolz is not a valid descriptor value for educationOrganizationCategoryDescriptor (at educationOrganizationCategories[0])",
                    "file": "./schools.jsonl",
                    "line_numbers":[3],
                    "count": 1
                }
            ],
            "records_processed": 300,
            "records_skipped": 0,
            "records_failed": 4
        }
    },
    "command": "validate",
    "completed_at": "2024-08-13T10:32:11.131360",
    "runtime_sec": 24.224361,
    "total_records_processed": 310,
    "total_records_skipped": 0,
    "total_records_failed": 4
}
```

Notes:
1. note the new top-level `command` key in the output: this expresses what `lightbeam` command was run to generate this output (`validate` or `send`).
2. currently the structured output file is written at the end of the `validate` and `send` process. Since `lightbeam validate+send` calls `validate` ad then `send`, the output file created for the `validate` step is subsequently overwritten by the `send` step. We therefore recommend against using `lightbeam validate+send --results-file ./results.json` in favor of two separate commands: `lightbeam validate --results-file ./results-validate.json && lightbeam send --results-file ./results-send.json`