### PR TITLE
allow deletion of students (if permitted by credential claimset and API auth strategy)

### DIFF
--- a/lightbeam/delete.py
+++ b/lightbeam/delete.py
@@ -36,12 +36,6 @@ class Deleter:
         self.lightbeam.confirm_delete(endpoints)
 
         for endpoint in endpoints:
-            # it doesn't seem possible to delete students once you've sent them
-            # (I think because other entities may have referenced them in the meantime)
-            if endpoint=='students':
-                self.logger.warn("data for {0} endpoint cannot be deleted (this is an Ed-Fi limitation); skipping".format(endpoint))
-                continue
-
             asyncio.run(self.do_deletes(endpoint))
             self.logger.info("finished processing endpoint {0}!".format(endpoint))
             self.logger.info("  (final status counts: {0})".format(self.lightbeam.status_counts))

--- a/lightbeam/truncate.py
+++ b/lightbeam/truncate.py
@@ -28,12 +28,6 @@ class Truncator:
         self.lightbeam.confirm_truncate(endpoints)
 
         for endpoint in endpoints:
-            # it doesn't seem possible to delete students once you've sent them
-            # (I think because other entities may have referenced them in the meantime)
-            # if endpoint=='students':
-            #     self.logger.warn("data for {0} endpoint cannot be deleted (this is an Ed-Fi limitation); skipping".format(endpoint))
-            #     continue
-
             asyncio.run(self.do_truncates(endpoint))
             self.logger.info("finished processing endpoint {0}!".format(endpoint))
             self.logger.info("  (final status counts: {0})".format(self.lightbeam.status_counts))


### PR DESCRIPTION
This PR removes the hard-coded prevention of `lightbeam delete` for `students`.

Note that if the Ed-Fi API uses a [relationship-based authorization strategy](https://edfi.atlassian.net/wiki/spaces/ODSAPIS3V500/pages/18350203/API+Claim+Sets+Resources#APIClaimSets&Resources-AuthorizationStrategies), you may run into the following situation:

You run `lightbeam delete`, which deletes records from resources in dependency-order. Since `studentEducationOrganizationAssociations` depend on `students`, the `stuEdOrgAssns` are (successfully) deleted first. However, now your EdOrg no longer has any relationship to your students, so when lightbeam subsequently attempts to delete `students`, the API returns 403 unauthorized status codes. There is no way to delete these students with your API credentials.

If you see many 403 errors when `lightbeam delete`ing students, you may need to obtain new Ed-Fi API credentials with a different authorization strategy and try again.