### PR TITLE
Allow simple filename as `ressults-file`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased changes
+
+* bugfix: `--results-file` required a directory prefix`
+
 ### v0.1.5
 <details>
 <summary>Released 2024-07-23</summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Unreleased changes
 
-* bugfix: `--results-file` required a directory prefix`
+* bugfix: `--results-file` required a directory prefix
 
 ### v0.1.5
 <details>

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -80,7 +80,7 @@ class Lightbeam:
         self.truncator = Truncator(self)
         self.api = EdFiAPI(self)
         self.token_version = 0        
-        self.results_file = results_file
+        self.results_file = os.path.abspath(results_file)
         self.start_timestamp = datetime.now()
 
         # load params and/or env vars for config YAML interpolation

--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -80,7 +80,7 @@ class Lightbeam:
         self.truncator = Truncator(self)
         self.api = EdFiAPI(self)
         self.token_version = 0        
-        self.results_file = os.path.abspath(results_file)
+        self.results_file = os.path.abspath(results_file) if results_file else None
         self.start_timestamp = datetime.now()
 
         # load params and/or env vars for config YAML interpolation


### PR DESCRIPTION
Currently, this won't work:

```sh
lightbeam fetch --results-file results.json
```

You have to include a directory:

```sh
lightbeam fetch --results-file ./results.json
```

The former should be allowed