### PR TITLE
fix structured results record counts

### DIFF
--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -255,6 +255,7 @@ class Lightbeam:
                         if os.path.isfile(sub_dir_item_path):
                             filename = os.path.basename(sub_dir_item)
                             extension = filename.rsplit(".", 1)[-1]
+                            filename_without_extension = filename.rsplit(".", 1)[0]
                             if (
                                 extension in self.DATA_FILE_EXTENSIONS # valid file extension
                                 and filename_without_extension in self.all_endpoints # valid endpoint

--- a/lightbeam/validate.py
+++ b/lightbeam/validate.py
@@ -225,6 +225,11 @@ class Validator:
 
             if len(tasks)>0: await self.lightbeam.do_tasks(tasks, total_counter, log_status_counts=False)
 
+            # update metadata counts
+            self.lightbeam.metadata["resources"][endpoint]["records_processed"] = total_counter
+            self.lightbeam.metadata["resources"][endpoint]["records_skipped"] = self.lightbeam.num_skipped
+            self.lightbeam.metadata["resources"][endpoint]["records_failed"] = self.lightbeam.num_errors
+            
             if self.lightbeam.num_errors==0: self.logger.info(f"... all lines validate ok!")
             else:
                 num_others = self.lightbeam.num_errors - self.MAX_VALIDATION_ERRORS_TO_DISPLAY


### PR DESCRIPTION
@johncmerfeld pointed out that `record_counts` in the structure `--results-file` are sometimes (incorrectly) `0`. This PR fixes that bug, as well as another bug that only happened when processing _directories_ of JSONL files.