### PR TITLE
fix discovery of data in subfolders of `data_dir`

### DIFF
--- a/lightbeam/lightbeam.py
+++ b/lightbeam/lightbeam.py
@@ -255,9 +255,10 @@ class Lightbeam:
                         if os.path.isfile(sub_dir_item_path):
                             filename = os.path.basename(sub_dir_item)
                             extension = filename.rsplit(".", 1)[-1]
+                            filename_without_extension = filename.rsplit(".", 1)[0]
                             if (
                                 extension in self.DATA_FILE_EXTENSIONS # valid file extension
-                                and filename_without_extension in self.all_endpoints # valid endpoint
+                                and data_dir_item in self.all_endpoints # valid endpoint
                                 and data_dir_item in filter_endpoints # selected endpoint
                             ):
                                 has_data_file = True


### PR DESCRIPTION
`lightbeam` looks for JSONL files in `data_dir` that correspond to an Ed-Fi endpoint (such as `students.jsonl`), and also subfolders in `data_dir` (such as `students/*.jsonl`). However, the data discovery code had a bug which would cause it to (silently!) skip/ignore such subfolders. This PR fixes the bug.