### PR TITLE
bugfix: failed `send` could bury error message coming from ODS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased changes
-* bugfix: `validate` and `send` could incorrect number of total records
+* bugfix: failed `send` could bury error message coming from ODS
+* bugfix: `validate` and `send` could show incorrect number of total records
 
 ### v0.1.6
 <details>


### PR DESCRIPTION
Fixes an edge case that results in Lightbeam logging a Python error message instead of the ODS error message

Let's say you send an invalid payload and get a 400 response. I'm not sure exactly what changed (or when) on the ODS side, – it's possible this is only a problem in the local ODS I'm running – but the `do_post` function makes assumptions about the structure of the error response payload that don't always match what is returned.

Currently:
  - Code expects `"message"` to be a field in the response body, and passes its value to `linearize`: `util.linearize(json.loads(body).get("message")`
  - If `"message"` is not present in the body, `linearize` throws a `TypeError` when it tries to perform a string operation on `None`
  - This `TypeError` gets caught by `do_post`'s general exception catcher: `except Exception` and gets logged as an ordinary error
  - The real error reported by the ODS is dropped

This change:
  - Supports both `"message"` and `"errors"` syntax coming from the ODS - `"errors"` comes as a list of strings
  - Allow an empty log message in the base case
  - Changes the generic `Exception` to a `ValueError` to reduce the likelihood that a Python error will get caught and reported

As I say, I don't know whether or when we'll see `"errors"` instead of `"message"` in the wild, but it is at least possible under some of the packages Ed-Fi has published and it's otherwise harmless. In any case, not catching the generic `Exception` is the deeper fix