### PR TITLE
Feature/http to https

### DIFF
--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -41,6 +41,7 @@ class EdFiAPI:
         except Exception as e:
             self.logger.critical("could not parse response from {0} ({1})".format(self.config["base_url"], str(e)))
 
+        # Change urls to https
         for k,v in api_base["urls"].items():
             v = v.split(':')
             if v[0] == 'http':
@@ -181,6 +182,8 @@ class EdFiAPI:
                 raise Exception("OpenAPI metadata URL returned status {0} ({1})".format(response.status_code, (response.content[:75] + "...") if len(response.content)>75 else response.content))
             openapi = response.json()
 
+
+            # Change endpoint to https
             for endpoint in openapi:
                 split_uri = endpoint["endpointUri"].split(':')
                 if split_uri[0] == 'http':

--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -41,7 +41,7 @@ class EdFiAPI:
         except Exception as e:
             self.logger.critical("could not parse response from {0} ({1})".format(self.config["base_url"], str(e)))
 
-        # Change urls to https
+        # If urls are 'http', change to 'https'
         for k,v in api_base["urls"].items():
             v = v.split(':')
             if v[0] == 'http':
@@ -183,7 +183,7 @@ class EdFiAPI:
             openapi = response.json()
 
 
-            # Change endpoint to https
+            # If endpoints are 'http', change to 'https'
             for endpoint in openapi:
                 split_uri = endpoint["endpointUri"].split(':')
                 if split_uri[0] == 'http':

--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -181,6 +181,12 @@ class EdFiAPI:
                 raise Exception("OpenAPI metadata URL returned status {0} ({1})".format(response.status_code, (response.content[:75] + "...") if len(response.content)>75 else response.content))
             openapi = response.json()
 
+            for endpoint in openapi:
+                split_uri = endpoint["endpointUri"].split(':')
+                if split_uri[0] == 'http':
+                    split_uri[0] = 'https'
+                endpoint["endpointUri"] = f"{split_uri[0]}:{split_uri[1]}"
+
         except Exception as e:
             self.logger.critical("Unable to load Swagger docs from API... terminating. Check API connectivity.")
 

--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -41,6 +41,13 @@ class EdFiAPI:
         except Exception as e:
             self.logger.critical("could not parse response from {0} ({1})".format(self.config["base_url"], str(e)))
 
+        for k,v in api_base["urls"].items():
+            v = v.split(':')
+            if v[0] == 'http':
+                v[0] = 'https'
+            v = f"{v[0]}:{v[1]}"
+            api_base["urls"][k] = v
+
         self.config["oauth_url"] = api_base["urls"]["oauth"]
         self.config["dependencies_url"] = api_base["urls"]["dependencies"]
         self.config["data_url"] = self.get_data_url()

--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -196,9 +196,7 @@ class EdFiAPI:
                 else:
                     self.logger.debug(f"fetching {endpoint_type} swagger doc...")
                     try:
-                        response = requests.get(swagger_url,
-                                                    verify=self.lightbeam.config["connection"]["verify_ssl"]
-                                                    )
+                        response = self.get_with_protocol_fallback(self.config[endpoint_type], endpoint_type)
                         if not response.ok:
                             raise Exception("OpenAPI metadata URL returned status {0} ({1})".format(response.status_code, (response.content[:75] + "...") if len(response.content)>75 else response.content))
                         swagger = response.json()


### PR DESCRIPTION
ugly hack to change any urls in the api metadata from http to https.  Addresses [issue ](https://educationanalytics.monday.com/boards/2610522828/pulses/8330071703) in Boston in which the earthbeam dag is failing to get the dependencies endpoint while trying to load MAP assessment data.

## Changes to existing files:
- `api.py` : adds an if statement in two places to check for  'http'.</br>

## Tests and QC done:
- tested on Boston 2024 'sandbox' ODS