### PR TITLE
Feature/check for http

### DIFF
--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -230,7 +230,7 @@ class EdFiAPI:
                 else:
                     self.logger.debug(f"fetching {endpoint_type} swagger doc...")
                     try:
-                        response = self.get_with_protocol_fallback(self.config[endpoint_type], endpoint_type)
+                        response = self.get_with_protocol_fallback(swagger_url, endpoint_type)
                         if not response.ok:
                             raise Exception("OpenAPI metadata URL returned status {0} ({1})".format(response.status_code, (response.content[:75] + "...") if len(response.content)>75 else response.content))
                         swagger = response.json()

--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -98,14 +98,28 @@ class EdFiAPI:
     # Obtains an OAuth token from the API and sets the client headers accordingly
     def do_oauth(self):
         try:
-            token_response = requests.post(
-                self.config["oauth_url"],
-                data={"grant_type":"client_credentials"},
-                auth=(
-                    self.config["client_id"],
-                    self.config["client_secret"]
-                    ),
-                verify=self.lightbeam.config["connection"]["verify_ssl"])
+            try:
+                token_response = requests.post(
+                    self.config["oauth_url"],
+                    data={"grant_type":"client_credentials"},
+                    auth=(
+                        self.config["client_id"],
+                        self.config["client_secret"]
+                        ),
+                    verify=self.lightbeam.config["connection"]["verify_ssl"])
+            except Exception as e:
+                try:
+                    swapped_url = self.config["oauth_url"].replace("http://", "https://") if "http://" in self.config["oauth_url"] else self.config["oauth_url"].replace("https://", "http://")
+                    token_response = requests.post(
+                        swapped_url,
+                        data={"grant_type":"client_credentials"},
+                        auth=(
+                            self.config["client_id"],
+                            self.config["client_secret"]
+                            ),
+                        verify=self.lightbeam.config["connection"]["verify_ssl"])
+                except Exception as e:
+                    self.logger.critical(f"could not reach {self.config['oauth_url']} ({str(e)})")    
             self.token = token_response.json()["access_token"]
             self.headers = {
                     "accept": "application/json",


### PR DESCRIPTION
This PR would add a feature to check for urls with `http` and try `https` instead.  `ssl_verify` will still always be true.  Tested on BPS ODS.