### PR TITLE
fix subarray uniqueness bug

### DIFF
--- a/lightbeam/validate.py
+++ b/lightbeam/validate.py
@@ -351,8 +351,7 @@ class Validator:
                         subarray_ref = subarray_definition['properties'][k].get('items',{}).get('$ref','')
                         if not self.identity_params_structures.get(subarray_ref, False):
                             self.identity_params_structures[subarray_ref] = self.lightbeam.api.get_identity_params_from_swagger(swagger, subarray_ref)
-                        if subarray_ref not in self.uniqueness_hashes.keys():
-                            self.uniqueness_hashes[subarray_ref] = []
+                        self.uniqueness_hashes[subarray_ref] = []
                         for i in range(0, len(payload[k])):
                             value = self.violates_uniqueness(subarray_ref, payload[k][i], path+("." if path!="" else "") + f"{k}[{i}]")
                             if value!="": return value


### PR DESCRIPTION
@johncmerfeld pointed out that `lightbeam validate` was throwing errors on the uniqueness check of subarrays even when elements of the arrays were, in fact, unique. This is because the structure used to track hashes of previously-seen elements was not emptied between records. This PR fixes that, emptying the tracking structure for every new record.