### PR TITLE
support new and improved error messages introduced in Ed-Fi API 7.2

### DIFF
--- a/lightbeam/send.py
+++ b/lightbeam/send.py
@@ -156,31 +156,51 @@ class Sender:
 
                         # warn about errors
                         if response.status not in [ 200, 201 ]:
-                            message = str(response.status) + ": " + util.linearize(json.loads(body).get("message"))
+                            response_body = json.loads(body)
+                            # Prior to Ed-Fi API 7.2 one would get a single (often not very useful)
+                            # error message for each POST. 7.2 introduced better error messages, 
+                            # and the possibility for a single POST to return several errors (if
+                            # different properties of the record fail validation for different
+                            # reasons). Therefore we now track and report each error separately.
+                            messages = []
+                            if "validationErrors" in response_body:
+                                # (Ed-Fi API >= 7.2 style errors)
+                                for json_path in response_body["validationErrors"].keys():
+                                    for error in response_body["validationErrors"][json_path]:
+                                        messages.append(f"{error} (at {json_path})")
+                            elif "errors" in response_body:
+                                # (Ed-Fi API >= 7.2 style errors)
+                                for error in response_body["errors"]:
+                                    messages.append(error)
+
+                            elif "message" in response_body:
+                                # (Ed-Fi API <= 7.1 style errors)
+                                messages.append(str(response.status) + ": " + util.linearize(response_body.get("message", "")))
 
                             # update run metadata...
                             failures = self.lightbeam.metadata["resources"][endpoint].get("failures", [])
-                            do_append = True
-                            for index, item in enumerate(failures):
-                                if item["status_code"]==response.status and item["message"]==message and item["file"]==file_name:
-                                    failures[index]["line_numbers"].append(line_number)
-                                    failures[index]["count"] += 1
-                                    do_append = False
-                            if do_append:
-                                failure = {
-                                    'status_code': response.status,
-                                    'message': message,
-                                    'file': file_name,
-                                    'line_numbers': [line_number],
-                                    'count': 1
-                                }
-                                failures.append(failure)
+                            for message in messages:
+                                do_append = True
+                                for index, item in enumerate(failures):
+                                    if item["status_code"]==response.status and item["message"]==message and item["file"]==file_name:
+                                        failures[index]["line_numbers"].append(line_number)
+                                        failures[index]["count"] += 1
+                                        do_append = False
+                                if do_append:
+                                    failure = {
+                                        'status_code': response.status,
+                                        'message': message,
+                                        'file': file_name,
+                                        'line_numbers': [line_number],
+                                        'count': 1
+                                    }
+                                    failures.append(failure)
+                                self.lightbeam.increment_status_reason(message)
                             self.lightbeam.metadata["resources"][endpoint]["failures"] = failures
 
                             # update output and counters
-                            self.lightbeam.increment_status_reason(message)
                             if response.status==400:
-                                raise Exception(message)
+                                raise Exception("; ".join(messages))
                             else:
                                 self.lightbeam.num_errors += 1
 


### PR DESCRIPTION
This PR implements support for [the new-and-improved error messages introduced in Ed-Fi API 7.2](https://docs.ed-fi.org/reference/ods-api/whats-new/whats-new-in-prev-v7x-releases/#enhanced-api-error-handling).

Previously, POSTing an invalid payload to an Ed-Fi API endpoint would result in a response like
```json
{
  "status": 400,
  "message": "Unable to resolve value `uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education AgencyX` to an existing `EducationOrganizationCategoryDescriptor` resource.",
  ...
}
```
(usually only the first encountered error is reported, even though the payload may have multiple issues)

In 7.2, a new error response format was introduced, like
```json
{
  "detail": "Data validation failed. See 'validationErrors' for details.",
  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
  "title": "Data Validation Failed",
  "status": 400,
  "correlationId": "ce0fba7c-5be5-48ac-a507-02451cff1ac9",
  "validationErrors": {
    "$.localEducationAgencyCategoryDescriptor": [
      "LocalEducationAgencyCategoryDescriptor value 'uri://ed-fi.org/LocalEducationAgencyCategoryDescriptor#CharterX' does not exist."
    ],
    "$.categories[0].educationOrganizationCategoryDescriptor": [
      "EducationOrganizationCategoryDescriptor value 'uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education AgencyX' does not exist."
    ]
  }
}
```
(multiple errors can be reported for a single POSTed payload)

Since `lightbeam` was previously looking only for the key `messages` in an error response payload, it would fail with an error on 7.2+ APIs.

This PR keeps support for the old error format and adds support for the new format. The main thing that's impacted is the `--results-file`: whereas previously it would report at most one error per file line-number:
```json
{
    "started_at": "2025-07-24T14:06:46.011324",
    "working_dir": "/xxxxxxxxx/repos/lightbeam/example",
    "config_file": "./lightbeam.yml",
    "data_dir": "./",
    "api_url": "https://localhost/api",
    "namespace": "ed-fi",
    "resources": {
        "localEducationAgencies": {
            "failures": [
                {
                    "status_code": 400,
                    "message": "400: Unable to resolve value `uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education AgencyX` to an existing `EducationOrganizationCategoryDescriptor` resource.",
                    "file": "./localEducationAgencies.jsonl",
                    "line_numbers":[1],
                    "count": 1
                }
            ],
            "records_processed": 1,
            "records_skipped": 0,
            "records_failed": 1
        }
    },
    "command": "send",
    "completed_at": "2025-07-24T14:08:22.745435",
    "runtime_sec": 96.734111,
    "total_records_processed": 1,
    "total_records_skipped": 0,
    "total_records_failed": 1
}
```

now it will be possible (when communicating with a 7.2+ API) to get multiple errors per single line of a file:
```json
{
    "started_at": "2025-07-24T13:13:13.041002",
    "working_dir": "/xxxxxxxxx/repos/lightbeam/example",
    "config_file": "./lightbeam.yml",
    "data_dir": "./",
    "api_url": "https://localhost/api",
    "namespace": "ed-fi",
    "resources": {
        "localEducationAgencies": {
            "failures": [
                {
                    "status_code": 400,
                    "message": "LocalEducationAgencyCategoryDescriptor value 'uri://ed-fi.org/LocalEducationAgencyCategoryDescriptor#CharterX' does not exist. (at $.localEducationAgencyCategoryDescriptor)",
                    "file": "./localEducationAgencies.jsonl",
                    "line_numbers":[1],
                    "count": 1
                },
                {
                    "status_code": 400,
                    "message": "EducationOrganizationCategoryDescriptor value 'uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education AgencyX' does not exist. (at $.categories[0].educationOrganizationCategoryDescriptor)",
                    "file": "./localEducationAgencies.jsonl",
                    "line_numbers":[1],
                    "count": 1
                }
            ],
            "records_processed": 1,
            "records_skipped": 0,
            "records_failed": 1
        }
    },
    "command": "send",
    "completed_at": "2025-07-24T13:13:13.364387",
    "runtime_sec": 0.323385,
    "total_records_processed": 1,
    "total_records_skipped": 0,
    "total_records_failed": 1
}
```

I think this makes sense, but am open to feedback/concerns.

The [edu_data_quality_monitoring](https://github.com/edanalytics/edu_data_quality_monitoring) package unpacks this results-file format; I looked at it and it doesn't _seem_ like this `lightbeam` change will affect that, but I could be wrong. @rlittle08 could perhaps confirm this change won't break the EDU package?

I've tested this against Ed-Fi API versions 5.3, 6.0, 7.0, 7.1, 7.2, and 7.3; all worked with no errors.