### PR TITLE
Harden `count` error handling

### DIFF
--- a/lightbeam/count.py
+++ b/lightbeam/count.py
@@ -62,7 +62,21 @@ class Counter:
                     ) as response:
                     body = await response.text()
                     status = str(response.status)
-                    if status == '401':
+                    if status != '401':
+                        if status not in ['200', '201']:
+                            self.logger.warn(f"Unable to load counts for {endpoint}... {status} API response: {body}")
+                            self.lightbeam.results.append([endpoint, f"error ({status}): {body}"])
+                            self.lightbeam.num_errors += 1
+                        else:
+                            total_count = int(response.headers.get("Total-Count", "-1"))
+                            if total_count < 0:
+                                self.logger.warn(f"Unable to load counts for {endpoint}... no Total-Count header in response: {body}")
+                                self.lightbeam.results.append([endpoint, f"error: no Total-Count header"])
+                                self.lightbeam.num_errors += 1
+                            else:
+                                self.lightbeam.results.append([endpoint, total_count])
+                        break
+                    else:
                         if self.lightbeam.token_version == curr_token_version:
                             self.lightbeam.lock.acquire()
                             self.lightbeam.api.update_oauth()
@@ -70,20 +84,6 @@ class Counter:
                         else:
                             await asyncio.sleep(1)
                         curr_token_version = int(str(self.lightbeam.token_version))
-                    elif status not in ['200', '201']:
-                        self.logger.warn(f"Unable to load counts for {endpoint}... {status} API response: {body}")
-                        self.lightbeam.results.append([endpoint, f"error ({status}): {body}"])
-                        self.lightbeam.num_errors += 1
-                        break
-                    else:
-                        total_count = int(response.headers.get("Total-Count", "-1"))
-                        if total_count < 0:
-                            self.logger.warn(f"Unable to load counts for {endpoint}... no Total-Count header in response: {body}")
-                            self.lightbeam.results.append([endpoint, f"error: no Total-Count header"])
-                            self.lightbeam.num_errors += 1
-                        else:
-                            self.lightbeam.results.append([endpoint, total_count])
-                        break
 
             except RuntimeError as e:
                 await asyncio.sleep(1)

--- a/lightbeam/count.py
+++ b/lightbeam/count.py
@@ -31,8 +31,8 @@ class Counter:
             # print header
             print("Records" + self.lightbeam.config["count"]["separator"] + "Endpoint")
             for result in self.lightbeam.results:
-                # when printing to the console, only include endpoints with >0 records
-                if result[1] > 0:
+                # when printing to the console, only include endpoints with >0 records or errors
+                if not isinstance(result[1], int) or result[1] > 0:
                     # print row
                     print(str(result[1]) + self.lightbeam.config["count"]["separator"] + result[0])
     
@@ -50,28 +50,44 @@ class Counter:
         await self.lightbeam.do_tasks(tasks, counter, log_status_counts=False)
     
     async def get_record_count(self, endpoint, params={}):
-        try:
-            # don't bother with handling 401 token expiry (like `send` and `delete` do)
-            # since `count` should finish _very_ quickly - way before expiry
-            params.update({ "limit": "0", "totalCount": "true" })
-            async with self.lightbeam.api.client.get(
-                util.url_join(self.lightbeam.api.config["data_url"], self.lightbeam.get_namespace_for_endpoint(endpoint), endpoint),
-                params=params,
-                ssl=self.lightbeam.config["connection"]["verify_ssl"],
-                headers=self.lightbeam.api.headers
-                ) as response:
-                body = await response.text()
-                status = str(response.status)
-                if status not in ['200', '201']:
-                    self.logger.warn(f"Unable to load counts for {endpoint}... {status} API response.")
-                else:
-                    total_count = int(response.headers.get("Total-Count", "-1"))
-                    if total_count < 0:
-                        self.logger.warn(f"Unable to load counts for {endpoint}...")
+        curr_token_version = int(str(self.lightbeam.token_version))
+        while True:
+            try:
+                params.update({ "limit": "0", "totalCount": "true" })
+                async with self.lightbeam.api.client.get(
+                    util.url_join(self.lightbeam.api.config["data_url"], self.lightbeam.get_namespace_for_endpoint(endpoint), endpoint),
+                    params=params,
+                    ssl=self.lightbeam.config["connection"]["verify_ssl"],
+                    headers=self.lightbeam.api.headers
+                    ) as response:
+                    body = await response.text()
+                    status = str(response.status)
+                    if status == '401':
+                        if self.lightbeam.token_version == curr_token_version:
+                            self.lightbeam.lock.acquire()
+                            self.lightbeam.api.update_oauth()
+                            self.lightbeam.lock.release()
+                        else:
+                            await asyncio.sleep(1)
+                        curr_token_version = int(str(self.lightbeam.token_version))
+                    elif status not in ['200', '201']:
+                        self.logger.warn(f"Unable to load counts for {endpoint}... {status} API response: {body}")
+                        self.lightbeam.results.append([endpoint, f"error ({status}): {body}"])
                         self.lightbeam.num_errors += 1
+                        self.lightbeam.num_finished += 1
+                        break
                     else:
-                        self.lightbeam.results.append([endpoint, total_count])
-                self.lightbeam.num_finished += 1
+                        total_count = int(response.headers.get("Total-Count", "-1"))
+                        if total_count < 0:
+                            self.logger.warn(f"Unable to load counts for {endpoint}... no Total-Count header in response: {body}")
+                            self.lightbeam.results.append([endpoint, f"error: no Total-Count header"])
+                            self.lightbeam.num_errors += 1
+                        else:
+                            self.lightbeam.results.append([endpoint, total_count])
+                        self.lightbeam.num_finished += 1
+                        break
 
-        except Exception as e:
-            self.logger.critical(f"Unable to load counts for {endpoint} from API... terminating. Check API connectivity.")
+            except RuntimeError as e:
+                await asyncio.sleep(1)
+            except Exception as e:
+                self.logger.critical(f"Unable to load counts for {endpoint} from API... terminating. Check API connectivity.")

--- a/lightbeam/count.py
+++ b/lightbeam/count.py
@@ -74,7 +74,6 @@ class Counter:
                         self.logger.warn(f"Unable to load counts for {endpoint}... {status} API response: {body}")
                         self.lightbeam.results.append([endpoint, f"error ({status}): {body}"])
                         self.lightbeam.num_errors += 1
-                        self.lightbeam.num_finished += 1
                         break
                     else:
                         total_count = int(response.headers.get("Total-Count", "-1"))
@@ -84,10 +83,11 @@ class Counter:
                             self.lightbeam.num_errors += 1
                         else:
                             self.lightbeam.results.append([endpoint, total_count])
-                        self.lightbeam.num_finished += 1
                         break
 
             except RuntimeError as e:
                 await asyncio.sleep(1)
             except Exception as e:
                 self.logger.critical(f"Unable to load counts for {endpoint} from API... terminating. Check API connectivity.")
+
+        self.lightbeam.num_finished += 1

--- a/lightbeam/fetch.py
+++ b/lightbeam/fetch.py
@@ -49,7 +49,7 @@ class Fetcher:
         self.lightbeam.results = []
         for endpoint in self.lightbeam.endpoints:
             try:
-                num_records = [x for x in record_counts if x[0] == endpoint][0][1]
+                num_records = [x for x in record_counts if x[0] == endpoint and isinstance(x[1], int)][0][1]
             except IndexError:
                 continue
             num_pages = math.ceil(num_records / limit)


### PR DESCRIPTION
Runway has encountered issues fetching records from ODSs. It's hard to debug those issues because the `count` method, which runs before `fetch`, does not handle errors the same way that other methods do.

The two changes here:
  1. handle 401s – we have seen those in the wild so I believe diagnosability would improve if we could at least attempt a token refresh, and I see no cost to doing so
  2. Include the error text in the console output / results file. Again I see no cost to doing this, and adding more verbose errors elsewhere has reaped benefits.