### PR TITLE
Fix retry_statuses dropped because list.append() returns None

### DIFF
--- a/lightbeam/api.py
+++ b/lightbeam/api.py
@@ -91,7 +91,7 @@ class EdFiAPI:
             retry_options=ExponentialRetry(
                 attempts=self.lightbeam.config['connection']["num_retries"],
                 factor=self.lightbeam.config['connection']["backoff_factor"],
-                statuses=self.lightbeam.config['connection']["retry_statuses"].append(401)
+                statuses=[*self.lightbeam.config['connection']["retry_statuses"], 401]
                 ),
             connector=aiohttp.connector.TCPConnector(limit=self.lightbeam.config['connection']["pool_size"])
             )


### PR DESCRIPTION
### What
`EdFiAPI.get_retry_client()` builds its retry-status set as:

    statuses=self.lightbeam.config['connection']["retry_statuses"].append(401)

`list.append()` returns `None`, so `statuses=None` reaches `ExponentialRetry` and the configured `retry_statuses` (429/500/501/503/504) are dropped - a 429 rate-limit is never retried. It also mutates `config['connection']['retry_statuses']` in place, appending another `401` on every call.

### Fix
Build a fresh list - a copy of the configured statuses plus 401:

    statuses=[*self.lightbeam.config['connection']["retry_statuses"], 401]

One line; fixes both the dropped statuses and the in-place mutation. (The edit also adds a trailing newline at end of file - the second line in the diff.)

### Verified
`get_retry_client()` now retries `{429, 500, 501, 503, 504, 401}`, and the config list is unchanged across repeated calls.

Addresses the retry-client bug noted in the "Related bug (compounding)" section of #92.